### PR TITLE
feat!: network security groups can be optional now and small refactor…

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -32,6 +32,7 @@ module "network" {
     subnets = {
       sn1 = {
         cidr = ["10.18.1.0/24"]
+        nsg  = {}
         endpoints = [
           "Microsoft.Storage",
           "Microsoft.Sql"
@@ -39,9 +40,15 @@ module "network" {
       }
       sn2 = {
         cidr = ["10.18.2.0/24"]
+        nsg  = {}
         delegations = {
           databricks = {
             name = "Microsoft.Databricks/workspaces"
+            actions = [
+              "Microsoft.Network/virtualNetworks/subnets/join/action",
+              "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action",
+              "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action",
+            ]
           }
         }
       }
@@ -56,30 +63,32 @@ module "network" {
       }
       sn4 = {
         cidr = ["10.18.4.0/24"]
-        rules = [
-          {
-            name                       = "myhttps"
-            priority                   = 100
-            direction                  = "Inbound"
-            access                     = "Allow"
-            protocol                   = "Tcp"
-            source_port_range          = "*"
-            destination_port_range     = "443"
-            source_address_prefix      = "10.151.1.0/24"
-            destination_address_prefix = "*"
-          },
-          {
-            name                       = "mysql"
-            priority                   = 200
-            direction                  = "Inbound"
-            access                     = "Allow"
-            protocol                   = "Tcp"
-            source_port_range          = "*"
-            destination_port_range     = "3306"
-            source_address_prefix      = "10.0.0.0/24"
-            destination_address_prefix = "*"
+        nsg = {
+          rules = {
+            myhttps = {
+              name                       = "myhttps"
+              priority                   = 100
+              direction                  = "Inbound"
+              access                     = "Allow"
+              protocol                   = "Tcp"
+              source_port_range          = "*"
+              destination_port_range     = "443"
+              source_address_prefix      = "10.151.1.0/24"
+              destination_address_prefix = "*"
+            }
+            mysql = {
+              name                       = "mysql"
+              priority                   = 200
+              direction                  = "Inbound"
+              access                     = "Allow"
+              protocol                   = "Tcp"
+              source_port_range          = "*"
+              destination_port_ranges    = ["3306", "3307"]
+              source_address_prefixes    = ["10.0.0.0/24", "11.0.0.0/24"]
+              destination_address_prefix = "*"
+            }
           }
-        ]
+        }
       }
     }
   }

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -12,7 +12,7 @@ module "rg" {
   groups = {
     demo = {
       name   = module.naming.resource_group.name
-      region = "westeurope"
+      region = "northeurope"
     }
   }
 }

--- a/examples/delegations/main.tf
+++ b/examples/delegations/main.tf
@@ -12,7 +12,7 @@ module "rg" {
   groups = {
     demo = {
       name   = module.naming.resource_group.name
-      region = "westeurope"
+      region = "northeurope"
     }
   }
 }
@@ -32,6 +32,7 @@ module "network" {
     subnets = {
       sn1 = {
         cidr = ["10.18.1.0/24"]
+        nsg  = {}
         delegations = {
           sql = {
             name = "Microsoft.Sql/managedInstances"
@@ -45,6 +46,7 @@ module "network" {
       }
       sn2 = {
         cidr = ["10.18.2.0/24"]
+        nsg  = {}
         delegations = {
           web = { name = "Microsoft.Web/serverFarms" }
         }

--- a/examples/nsg-rules/locals.tf
+++ b/examples/nsg-rules/locals.tf
@@ -27,8 +27,8 @@ locals {
       access                     = "Allow"
       protocol                   = "Tcp"
       source_port_range          = "*"
-      destination_port_range     = "3306"
-      source_address_prefix      = "10.0.0.0/24"
+      destination_port_ranges    = ["3306", "3307"]
+      source_address_prefixes    = ["10.0.0.0/24", "11.0.0.0/24"]
       destination_address_prefix = "*"
     }
   }

--- a/examples/nsg-rules/main.tf
+++ b/examples/nsg-rules/main.tf
@@ -12,7 +12,7 @@ module "rg" {
   groups = {
     demo = {
       name   = module.naming.resource_group.name
-      region = "westeurope"
+      region = "northeurope"
     }
   }
 }

--- a/examples/routes/main.tf
+++ b/examples/routes/main.tf
@@ -12,7 +12,7 @@ module "rg" {
   groups = {
     demo = {
       name   = module.naming.resource_group.name
-      region = "westeurope"
+      region = "northeurope"
     }
   }
 }
@@ -33,13 +33,16 @@ module "network" {
       sn1 = {
         cidr        = ["10.18.1.0/24"]
         route_table = "shd"
+        nsg         = {}
       },
       sn2 = {
         cidr        = ["10.18.2.0/24"]
         route_table = "shd"
+        nsg         = {}
       },
       sn3 = {
         cidr = ["10.18.3.0/24"]
+        nsg  = {}
         route = {
           routes = {
             rt3 = {

--- a/examples/service-endpoints/main.tf
+++ b/examples/service-endpoints/main.tf
@@ -32,6 +32,7 @@ module "network" {
     subnets = {
       demo = {
         cidr = ["10.18.3.0/24"]
+        nsg  = {}
         endpoints = [
           "Microsoft.Storage",
           "Microsoft.Sql"

--- a/examples/vhub-connection/main.tf
+++ b/examples/vhub-connection/main.tf
@@ -31,6 +31,7 @@ module "network" {
 
     subnets = {
       sn1 = {
+        nsg  = {}
         cidr = ["10.19.1.0/24"]
       }
     }

--- a/locals.tf
+++ b/locals.tf
@@ -3,31 +3,48 @@ locals {
     for subnet_key, subnet in lookup(var.vnet, "subnets", {}) : subnet_key =>
     values(lookup(lookup(subnet, "nsg", {}), "rules", {}))
   }
+}
 
-  route_table_info = {
+locals {
+  nsg = {
     for subnet_key, subnet in lookup(var.vnet, "subnets", {}) : subnet_key => {
-      route_table     = lookup(subnet, "route", {})
+
+      nsg_name = try(subnet.nsg.name, join("-", [var.naming.network_security_group, subnet_key]))
+      rules    = local.nsg_rules[subnet_key]
+      tags     = try(subnet.nsg.tags, {})
+      location = var.vnet.location
+    }
+    if lookup(subnet, "nsg", null) != null
+  }
+}
+
+locals {
+  route = {
+    for subnet_key, subnet in lookup(var.vnet, "subnets", {}) : subnet_key => {
+      rt_name         = try(subnet.route.name, join("-", [var.naming.route_table, subnet_key]))
+      routes          = try(subnet.route.routes, {})
+      tags            = try(subnet.route.tags, {})
+      location        = var.vnet.location
+      route_table     = try(lookup(subnet, "route", {}), {})
       shd_route_table = try(subnet.route_table, null)
     }
+    if lookup(subnet, "route", null) != null || lookup(subnet, "route_table", null) != null
   }
+}
 
+locals {
   subnets = length(lookup(var.vnet, "subnets", {})) > 0 ? flatten([
     for subnet_key, subnet in lookup(var.vnet, "subnets", {}) : {
-      subnet_key                 = subnet_key
-      virtual_network_name       = azurerm_virtual_network.vnet.name
-      address_prefixes           = subnet.cidr
-      endpoints                  = try(subnet.endpoints, [])
-      enforce_priv_link_service  = try(subnet.enforce_priv_link_service, false)
-      enforce_priv_link_endpoint = try(subnet.enforce_priv_link_endpoint, false)
-      rules                      = local.nsg_rules[subnet_key]
-      subnet_name                = try(subnet.name, join("-", [var.naming.subnet, subnet_key]))
-      nsg_name                   = try(subnet.nsg.name, join("-", [var.naming.network_security_group, subnet_key]))
-      rt_name                    = try(subnet.route.name, join("-", [var.naming.route_table, subnet_key]), {})
-      location                   = var.vnet.location
-      routes                     = try(subnet.route.routes, {})
-      route_table                = local.route_table_info[subnet_key].route_table
-      shd_route_table            = local.route_table_info[subnet_key].shd_route_table
-
+      subnet_key                  = subnet_key
+      virtual_network_name        = azurerm_virtual_network.vnet.name
+      address_prefixes            = subnet.cidr
+      endpoints                   = try(subnet.endpoints, [])
+      enforce_priv_link_service   = try(subnet.enforce_priv_link_service, false)
+      enforce_priv_link_endpoint  = try(subnet.enforce_priv_link_endpoint, false)
+      service_endpoint_policy_ids = try(subnet.service_endpoint_policy_ids, null)
+      subnet_name                 = try(subnet.name, join("-", [var.naming.subnet, subnet_key]))
+      location                    = var.vnet.location
+      tags                        = try(subnet.nsg.tags, {})
       delegations = [for d in try(subnet.delegations, {}) : {
         name    = d.name
         actions = try(d.actions, [])


### PR DESCRIPTION
… data structure

∙ BREAKING CHANGE: To create network security groups and their associations, it is now required to explicitly define them within the config. In previous versions this was not needed, and without correct usage they will be removed. Please review the examples folder.