### PR TITLE
fix: refactor delegation key to actual key provided instead of a numbered index

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -47,9 +47,10 @@ locals {
       location                                      = coalesce(lookup(var.vnet, "location", null), var.location)
       tags                                          = try(subnet.nsg.tags, var.tags, null)
 
-      delegations = [for d in try(subnet.delegations, {}) : {
-        name    = d.name
-        actions = try(d.actions, [])
+      delegations = [for key, del in try(subnet.delegations, {}) : {
+        delegation_key = key
+        name           = del.name
+        actions        = try(del.actions, [])
       }]
     }
   ]) : []

--- a/main.tf
+++ b/main.tf
@@ -49,7 +49,7 @@ resource "azurerm_subnet" "subnets" {
     for_each = each.value.delegations
 
     content {
-      name = delegation.key
+      name = delegation.value.delegation_key
 
       service_delegation {
         name    = delegation.value.name


### PR DESCRIPTION
Changed delegation key to:
![image](https://github.com/CloudNationHQ/terraform-azure-vnet/assets/122470243/5c60dd20-0094-4409-bea4-a0327d53bc7e)
instead of :
![image](https://github.com/CloudNationHQ/terraform-azure-vnet/assets/122470243/5ddc2ab4-c1ed-4696-8a5d-49012b76b752)
