### PR TITLE
feat: add network security group output

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ A last key goal is to separate logic from configuration in the module, thereby e
 | :-- | :-- |
 | `vnet` | vnet setup details |
 | `subnets` | subnet configuration specifics |
+| `nsg` | network security group configuration specifics |
 | `subscriptionId` | contains the current subsriptionId |
 
 ## Testing

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,6 +6,10 @@ output "subnets" {
   value = azurerm_subnet.subnets
 }
 
+output "nsg" {
+  value = azurerm_network_security_group.nsg
+}
+
 output "subscriptionId" {
   value = data.azurerm_subscription.current.subscription_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 variable "vnet" {
-  description = "Contains all log analytics workspace settings"
+  description = "Contains all virtual network settings"
   type        = any
 }
 


### PR DESCRIPTION
## Description

<!-- Please include a description below with the reason for the PR, what it is doing, what it is trying to accomplish, and anything relevant for a reviewer to know. 

If this is a breaking change for users please detail how it cannot be avoided and why it should be made in a minor version of the provider -->


## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

## Change Log

Below please provide what should go into the changelog (if anything) 

<!-- Replace the changelog example below with your entry. One resource per line. -->

 * `azurerm_network_security_group` - add output
 * `azurerm_virtual_network` - correct vnet variable description

