### PR TITLE
fix: resolve type mismatch in nsg name coalesce

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -92,9 +92,9 @@ resource "azurerm_network_security_group" "this" {
     }
   )
 
-  name = coalesce(
-    lookup(each.value, "name", null),
-    try("${var.naming.network_security_group}-${each.key}", null)
+  name = try(
+    each.value.name,
+    "${var.naming.network_security_group}-${each.key}"
   )
 
   resource_group_name = lookup(var.vnet, "existing", null) != null ? var.vnet.existing.resource_group : coalesce(
@@ -194,9 +194,9 @@ resource "azurerm_route_table" "this" {
     }
   )
 
-  name = coalesce(
-    lookup(each.value, "name", null),
-    try("${var.naming.route_table}-${each.key}", null)
+  name = try(
+    each.value.name,
+    "${var.naming.route_table}-${each.key}"
   )
 
   resource_group_name = lookup(var.vnet, "existing", null) != null ? var.vnet.existing.resource_group : coalesce(


### PR DESCRIPTION
## Description

Using coalesce in combination with lookup gave a type mismatch on the network security group names. This PR replaced the function using try.

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)