### PR TITLE
fix: match time provider version with sqlmi

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -13,7 +13,7 @@ terraform {
     }
     time = {
       source  = "hashicorp/time"
-      version = "~> 0.10.0"
+      version = "~> 0.12"
     }
   }
 }


### PR DESCRIPTION
## Description

Change the time provider version to "~> 0.12" to match sqlmi version (and prevent version issues)

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)
