### PR TITLE
feat: ignore inline rules in network security groups and take current subscription as alias in peering usage

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,6 +1,6 @@
 module "naming" {
   source  = "cloudnationhq/naming/azure"
-  version = "~> 0.1"
+  version = "~> 0.22"
 
   suffix = ["demo", "dev"]
 }

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -1,6 +1,6 @@
 module "naming" {
   source  = "cloudnationhq/naming/azure"
-  version = "~> 0.1"
+  version = "~> 0.22"
 
   suffix = ["demo", "dev"]
 }

--- a/examples/delegations/main.tf
+++ b/examples/delegations/main.tf
@@ -1,6 +1,6 @@
 module "naming" {
   source  = "cloudnationhq/naming/azure"
-  version = "~> 0.1"
+  version = "~> 0.22"
 
   suffix = ["demo", "dev"]
 }

--- a/examples/nsg-rules/main.tf
+++ b/examples/nsg-rules/main.tf
@@ -1,6 +1,6 @@
 module "naming" {
   source  = "cloudnationhq/naming/azure"
-  version = "~> 0.1"
+  version = "~> 0.22"
 
   suffix = ["demo", "dev"]
 }

--- a/examples/peering/main.tf
+++ b/examples/peering/main.tf
@@ -1,6 +1,6 @@
 module "naming" {
   source  = "cloudnationhq/naming/azure"
-  version = "~> 0.1"
+  version = "~> 0.22"
 
   suffix = ["demo", "dev"]
 }

--- a/examples/peering/terraform.tf
+++ b/examples/peering/terraform.tf
@@ -15,6 +15,8 @@ provider "azurerm" {
 
 provider "azurerm" {
   alias           = "remote"
-  subscription_id = "00000000-0000-0000-0000-000000000000"
+  subscription_id = data.azurerm_subscription.current.subscription_id // current subscription to succeed tests
   features {}
 }
+
+data "azurerm_subscription" "current" {}

--- a/examples/routes/main.tf
+++ b/examples/routes/main.tf
@@ -1,6 +1,6 @@
 module "naming" {
   source  = "cloudnationhq/naming/azure"
-  version = "~> 0.1"
+  version = "~> 0.22"
 
   suffix = ["demo", "dev"]
 }

--- a/examples/service-endpoints/main.tf
+++ b/examples/service-endpoints/main.tf
@@ -1,6 +1,6 @@
 module "naming" {
   source  = "cloudnationhq/naming/azure"
-  version = "~> 0.1"
+  version = "~> 0.22"
 
   suffix = ["demo", "dev"]
 }

--- a/main.tf
+++ b/main.tf
@@ -108,6 +108,10 @@ resource "azurerm_network_security_group" "nsg" {
   )
 
   tags = try(var.vnet.tags, var.tags, {})
+
+  lifecycle {
+    ignore_changes = [security_rule]
+  }
 }
 
 # security rules


### PR DESCRIPTION
## Description

This PR ignores inline rule in subnets, as rules is a seperate resource. It also adds the current subscription as alias in the peering usage to succeed testing...

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)