### PR TITLE
fix: resolved race condition in network security group association

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -183,6 +183,10 @@ resource "azurerm_subnet_network_security_group_association" "nsg_as" {
   network_security_group_id = lookup(lookup(each.value, "shared", {}), "network_security_group", null) != null ? (
     azurerm_network_security_group.nsg[lookup(each.value.shared, "network_security_group")].id
   ) : azurerm_network_security_group.nsg[each.key].id
+
+  depends_on = [
+    azurerm_network_security_rule.rules
+  ]
 }
 
 # route tables


### PR DESCRIPTION
## Description

This PR adds a dependson that ensures that all nsg rules are applied before the association takes place.

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

```
=== NAME  TestApplyAllParallel/complete
    deploy_test.go:141: Cleaning up in: ../examples/complete
=== NAME  TestApplyAllParallel
    deploy_test.go:165: All modules applied and destroyed successfully.
--- PASS: TestApplyAllParallel (0.00s)
    --- PASS: TestApplyAllParallel/default (101.06s)
    --- PASS: TestApplyAllParallel/peering (139.60s)
    --- PASS: TestApplyAllParallel/service-endpoints (163.62s)
    --- PASS: TestApplyAllParallel/delegations (188.00s)
    --- PASS: TestApplyAllParallel/nsg-rules (226.34s)
    --- PASS: TestApplyAllParallel/routes (247.44s)
    --- PASS: TestApplyAllParallel/complete (252.41s)
PASS
ok      github.com/cloudnationhq/terraform-azure-vnet   252.763s
```

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)