### PR TITLE
fix: resolve type mismatches in network security groups

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -195,22 +195,6 @@ resource "azurerm_subnet_network_security_group_association" "nsg_as" {
   ]
 }
 
-resource "azurerm_subnet_network_security_group_association" "nsg_as" {
-  for_each = {
-    for subnet_key, subnet in lookup(var.vnet, lookup(var.vnet, "existing", null) != null ? "existing" : "", {}).subnets :
-      subnet_key => subnet
-    if lookup(lookup(subnet, "shared", {}), "network_security_group", null) != null ||
-       lookup(subnet, "network_security_group", null) != null
-  }
-
-  subnet_id = azurerm_subnet.subnets[each.key].id
-  network_security_group_id = lookup(lookup(each.value, "shared", {}), "network_security_group", null) != null ? azurerm_network_security_group.nsg[lookup(each.value.shared, "network_security_group")].id : azurerm_network_security_group.nsg[each.key].id
-
-  depends_on = [
-    azurerm_network_security_rule.rules
-  ]
-}
-
 # route tables
 resource "azurerm_route_table" "rt" {
   for_each = merge(

--- a/main.tf
+++ b/main.tf
@@ -79,32 +79,58 @@ resource "azurerm_subnet" "subnets" {
   }
 }
 
+# network security groups
+#resource "azurerm_network_security_group" "nsg" {
+#for_each = merge(
+## Handle top-level NSGs (shared ones)
+#lookup(var.vnet, "existing", null) != null ? lookup(lookup(var.vnet, "existing", {}), "network_security_groups", {}) : lookup(var.vnet, "network_security_groups", {}),
+
+## Handle subnet-level NSGs
+#(lookup(var.vnet, "existing", null) != null
+#? {
+#for subnet_key, subnet in lookup(lookup(var.vnet, "existing", {}), "subnets", {}) : subnet_key => merge(
+#{ name = "${var.naming.network_security_group}-${subnet_key}" },
+#lookup(subnet, "network_security_group", {})
+#)
+#if lookup(subnet, "network_security_group", null) != null
+#}
+#: {
+#for subnet_key, subnet in lookup(var.vnet, "subnets", {}) : subnet_key => merge(
+#{ name = "${var.naming.network_security_group}-${subnet_key}" },
+#lookup(subnet, "network_security_group", {})
+#)
+#if lookup(subnet, "network_security_group", null) != null
+#}
+#)
+#)
+
+#name = try(
+#each.value.name,
+#"${var.naming.network_security_group}-${each.key}"
+#)
+
+
+# network security groups
 resource "azurerm_network_security_group" "nsg" {
   for_each = merge(
+    # Handle top-level shared NSGs
     lookup(var.vnet, "existing", null) != null ? lookup(lookup(var.vnet, "existing", {}), "network_security_groups", {}) : lookup(var.vnet, "network_security_groups", {}),
-    lookup(var.vnet, "existing", null) != null ? {
-      for subnet_key, subnet in lookup(lookup(var.vnet, "existing", {}), "subnets", {}) : subnet_key => subnet.network_security_group
-      if lookup(subnet, "network_security_group", null) != null
-      } : {
-      for subnet_key, subnet in lookup(var.vnet, "subnets", {}) : subnet_key => subnet.network_security_group
+
+    # Handle subnet NSGs
+    {
+      for subnet_key, subnet in lookup(var.vnet, "subnets", {}) : subnet_key => lookup(subnet, "network_security_group", {})
       if lookup(subnet, "network_security_group", null) != null
     }
   )
 
-  name = try(
-    each.value.name,
-    "${var.naming.network_security_group}-${each.key}"
+  name = coalesce(
+    lookup(each.value, "name", null),
+    try("${var.naming.network_security_group}-${each.key}", null)
   )
 
-  resource_group_name = lookup(var.vnet, "existing", null) != null ? var.vnet.existing.resource_group : coalesce(
-    var.vnet.resource_group,
-    var.resource_group
-  )
+  resource_group_name = lookup(var.vnet, "existing", null) != null ? var.vnet.existing.resource_group : coalesce(var.vnet.resource_group, var.resource_group)
 
-  location = lookup(var.vnet, "existing", null) != null ? var.vnet.existing.location : coalesce(
-    var.vnet.location,
-    var.location
-  )
+  location = lookup(var.vnet, "existing", null) != null ? var.vnet.existing.location : coalesce(var.vnet.location, var.location)
 
   tags = try(var.vnet.tags, var.tags, {})
 
@@ -112,6 +138,40 @@ resource "azurerm_network_security_group" "nsg" {
     ignore_changes = [security_rule]
   }
 }
+
+#resource "azurerm_network_security_group" "nsg" {
+#for_each = merge(
+#lookup(var.vnet, "existing", null) != null ? lookup(lookup(var.vnet, "existing", {}), "network_security_groups", {}) : lookup(var.vnet, "network_security_groups", {}),
+#lookup(var.vnet, "existing", null) != null ? {
+#for subnet_key, subnet in lookup(lookup(var.vnet, "existing", {}), "subnets", {}) : subnet_key => subnet.network_security_group
+#if lookup(subnet, "network_security_group", null) != null
+#} : {
+#for subnet_key, subnet in lookup(var.vnet, "subnets", {}) : subnet_key => subnet.network_security_group
+#if lookup(subnet, "network_security_group", null) != null
+#}
+#)
+
+#name = try(
+#each.value.name,
+#"${var.naming.network_security_group}-${each.key}"
+#)
+
+#resource_group_name = lookup(var.vnet, "existing", null) != null ? var.vnet.existing.resource_group : coalesce(
+#var.vnet.resource_group,
+#var.resource_group
+#)
+
+#location = lookup(var.vnet, "existing", null) != null ? var.vnet.existing.location : coalesce(
+#var.vnet.location,
+#var.location
+#)
+
+#tags = try(var.vnet.tags, var.tags, {})
+
+#lifecycle {
+#ignore_changes = [security_rule]
+#}
+#}
 
 # security rules
 resource "azurerm_network_security_rule" "rules" {

--- a/main.tf
+++ b/main.tf
@@ -171,31 +171,16 @@ resource "azurerm_subnet_network_security_group_association" "nsg_as" {
   for_each = {
     for subnet_key, subnet in lookup(var.vnet, "subnets", {}) : subnet_key => subnet
     if lookup(lookup(subnet, "shared", {}), "network_security_group", null) != null ||
-       lookup(subnet, "network_security_group", null) != null
+    lookup(subnet, "network_security_group", null) != null
   }
 
-  subnet_id = azurerm_subnet.subnets[each.key].id
+  subnet_id                 = azurerm_subnet.subnets[each.key].id
   network_security_group_id = lookup(lookup(each.value, "shared", {}), "network_security_group", null) != null ? azurerm_network_security_group.nsg[lookup(each.value.shared, "network_security_group")].id : azurerm_network_security_group.nsg[each.key].id
 
   depends_on = [
     azurerm_network_security_rule.rules
   ]
 }
-#resource "azurerm_subnet_network_security_group_association" "nsg_as" {
-  #for_each = {
-    #for subnet_key, subnet in lookup(lookup(var.vnet, "existing", {}), "subnets", lookup(var.vnet, "subnets", {})) : subnet_key => subnet
-    #if lookup(lookup(subnet, "shared", {}), "network_security_group", null) != null || lookup(subnet, "network_security_group", null) != null
-  #}
-
-  #subnet_id = azurerm_subnet.subnets[each.key].id
-  #network_security_group_id = lookup(lookup(each.value, "shared", {}), "network_security_group", null) != null ? (
-    #azurerm_network_security_group.nsg[lookup(each.value.shared, "network_security_group")].id
-  #) : azurerm_network_security_group.nsg[each.key].id
-
-  #depends_on = [
-    #azurerm_network_security_rule.rules
-  #]
-#}
 
 # route tables
 resource "azurerm_route_table" "rt" {

--- a/main.tf
+++ b/main.tf
@@ -85,12 +85,15 @@ resource "azurerm_network_security_group" "nsg" {
     # Handle top-level NSGs (shared ones)
     lookup(var.vnet, "network_security_groups", {}),
 
-    # Handle subnet-level NSGs
+    # Handle subnet-level NSGs by first constructing the proper subnet map
     {
       for subnet_key, subnet in (
-        lookup(var.vnet, "existing", null) != null ?
-          lookup(lookup(var.vnet, "existing", {}), "subnets", {}) :
-          lookup(var.vnet, "subnets", {})
+        # First create a local to handle the subnets lookup
+        # to ensure consistent types between both paths
+        merge(
+          lookup(lookup(var.vnet, "existing", {}), "subnets", {}),
+          lookup(var.vnet, "existing", null) == null ? lookup(var.vnet, "subnets", {}) : {}
+        )
       ) : subnet_key => (
         lookup(lookup(subnet, "shared", {}), "network_security_group", null) != null ?
           lookup(lookup(var.vnet, "network_security_groups", {}), lookup(subnet.shared, "network_security_group")) :
@@ -116,6 +119,44 @@ resource "azurerm_network_security_group" "nsg" {
     ignore_changes = [security_rule]
   }
 }
+
+ #network security groups
+#resource "azurerm_network_security_group" "nsg" {
+  #for_each = merge(
+     #Handle top-level NSGs (shared ones)
+    #lookup(var.vnet, "network_security_groups", {}),
+
+     #Handle subnet-level NSGs
+    #{
+      #for subnet_key, subnet in (
+        #lookup(var.vnet, "existing", null) != null ?
+          #lookup(lookup(var.vnet, "existing", {}), "subnets", {}) :
+          #lookup(var.vnet, "subnets", {})
+      #) : subnet_key => (
+        #lookup(lookup(subnet, "shared", {}), "network_security_group", null) != null ?
+          #lookup(lookup(var.vnet, "network_security_groups", {}), lookup(subnet.shared, "network_security_group")) :
+          #lookup(subnet, "network_security_group", {})
+      #)
+      #if lookup(lookup(subnet, "shared", {}), "network_security_group", null) != null ||
+         #lookup(subnet, "network_security_group", null) != null
+    #}
+  #)
+
+  #name = try(
+    #each.value.name,
+    #"${var.naming.network_security_group}-${each.key}"
+  #)
+
+  #resource_group_name = lookup(var.vnet, "existing", null) != null ? var.vnet.existing.resource_group : coalesce(var.vnet.resource_group, var.resource_group)
+
+  #location = lookup(var.vnet, "existing", null) != null ? var.vnet.existing.location : coalesce(var.vnet.location, var.location)
+
+  #tags = try(var.vnet.tags, var.tags, {})
+
+  #lifecycle {
+    #ignore_changes = [security_rule]
+  #}
+#}
 
 # security rules
 resource "azurerm_network_security_rule" "rules" {
@@ -178,10 +219,9 @@ resource "azurerm_network_security_rule" "rules" {
 # nsg associations
 resource "azurerm_subnet_network_security_group_association" "nsg_as" {
   for_each = {
-    for subnet_key, subnet in (
-      lookup(var.vnet, "existing", null) != null ?
-        lookup(lookup(var.vnet, "existing", {}), "subnets", {}) :
-        lookup(var.vnet, "subnets", {})
+    for subnet_key, subnet in merge(
+      lookup(lookup(var.vnet, "existing", {}), "subnets", {}),
+      lookup(var.vnet, "existing", null) == null ? lookup(var.vnet, "subnets", {}) : {}
     ) : subnet_key => subnet
     if lookup(lookup(subnet, "shared", {}), "network_security_group", null) != null ||
        lookup(subnet, "network_security_group", null) != null
@@ -194,6 +234,26 @@ resource "azurerm_subnet_network_security_group_association" "nsg_as" {
     azurerm_network_security_rule.rules
   ]
 }
+
+ #nsg associations
+#resource "azurerm_subnet_network_security_group_association" "nsg_as" {
+  #for_each = {
+    #for subnet_key, subnet in (
+      #lookup(var.vnet, "existing", null) != null ?
+        #lookup(lookup(var.vnet, "existing", {}), "subnets", {}) :
+        #lookup(var.vnet, "subnets", {})
+    #) : subnet_key => subnet
+    #if lookup(lookup(subnet, "shared", {}), "network_security_group", null) != null ||
+       #lookup(subnet, "network_security_group", null) != null
+  #}
+
+  #subnet_id = azurerm_subnet.subnets[each.key].id
+  #network_security_group_id = lookup(lookup(each.value, "shared", {}), "network_security_group", null) != null ? azurerm_network_security_group.nsg[lookup(each.value.shared, "network_security_group")].id : azurerm_network_security_group.nsg[each.key].id
+
+  #depends_on = [
+    #azurerm_network_security_rule.rules
+  #]
+#}
 
 # route tables
 resource "azurerm_route_table" "rt" {

--- a/main.tf
+++ b/main.tf
@@ -87,7 +87,9 @@ resource "azurerm_network_security_group" "nsg" {
 
     # Handle subnet NSGs
     {
-      for subnet_key, subnet in lookup(var.vnet, "subnets", {}) : subnet_key => lookup(subnet, "network_security_group", {})
+      #for subnet_key, subnet in lookup(var.vnet, "subnets", {}) : subnet_key => lookup(subnet, "network_security_group", {})
+      #if lookup(subnet, "network_security_group", null) != null
+      for subnet_key, subnet in lookup(lookup(var.vnet, "existing", {}), "subnets", lookup(var.vnet, "subnets", {})) : subnet_key => lookup(subnet, "network_security_group", null)
       if lookup(subnet, "network_security_group", null) != null
     }
   )
@@ -166,16 +168,34 @@ resource "azurerm_network_security_rule" "rules" {
   )
 }
 
+# FIX: nsg + associoation is not working on existing virtual network
 # nsg associations
+#resource "azurerm_subnet_network_security_group_association" "nsg_as" {
+#for_each = {
+#for subnet_key, subnet in lookup(var.vnet, "subnets", {}) : subnet_key => subnet
+#if lookup(lookup(subnet, "shared", {}), "network_security_group", null) != null ||
+#lookup(subnet, "network_security_group", null) != null
+#}
+
+#subnet_id                 = azurerm_subnet.subnets[each.key].id
+#network_security_group_id = lookup(lookup(each.value, "shared", {}), "network_security_group", null) != null ? azurerm_network_security_group.nsg[lookup(each.value.shared, "network_security_group")].id : azurerm_network_security_group.nsg[each.key].id
+
+#depends_on = [
+#azurerm_network_security_rule.rules
+#]
+#}
+
+
 resource "azurerm_subnet_network_security_group_association" "nsg_as" {
   for_each = {
-    for subnet_key, subnet in lookup(var.vnet, "subnets", {}) : subnet_key => subnet
-    if lookup(lookup(subnet, "shared", {}), "network_security_group", null) != null ||
-    lookup(subnet, "network_security_group", null) != null
+    for subnet_key, subnet in lookup(lookup(var.vnet, "existing", {}), "subnets", lookup(var.vnet, "subnets", {})) : subnet_key => subnet
+    if lookup(lookup(subnet, "shared", {}), "network_security_group", null) != null || lookup(subnet, "network_security_group", null) != null
   }
 
-  subnet_id                 = azurerm_subnet.subnets[each.key].id
-  network_security_group_id = lookup(lookup(each.value, "shared", {}), "network_security_group", null) != null ? azurerm_network_security_group.nsg[lookup(each.value.shared, "network_security_group")].id : azurerm_network_security_group.nsg[each.key].id
+  subnet_id = azurerm_subnet.subnets[each.key].id
+  network_security_group_id = lookup(lookup(each.value, "shared", {}), "network_security_group", null) != null ? (
+    azurerm_network_security_group.nsg[lookup(each.value.shared, "network_security_group")].id
+  ) : azurerm_network_security_group.nsg[each.key].id
 
   depends_on = [
     azurerm_network_security_rule.rules

--- a/main.tf
+++ b/main.tf
@@ -80,37 +80,6 @@ resource "azurerm_subnet" "subnets" {
 }
 
 # network security groups
-#resource "azurerm_network_security_group" "nsg" {
-#for_each = merge(
-## Handle top-level NSGs (shared ones)
-#lookup(var.vnet, "existing", null) != null ? lookup(lookup(var.vnet, "existing", {}), "network_security_groups", {}) : lookup(var.vnet, "network_security_groups", {}),
-
-## Handle subnet-level NSGs
-#(lookup(var.vnet, "existing", null) != null
-#? {
-#for subnet_key, subnet in lookup(lookup(var.vnet, "existing", {}), "subnets", {}) : subnet_key => merge(
-#{ name = "${var.naming.network_security_group}-${subnet_key}" },
-#lookup(subnet, "network_security_group", {})
-#)
-#if lookup(subnet, "network_security_group", null) != null
-#}
-#: {
-#for subnet_key, subnet in lookup(var.vnet, "subnets", {}) : subnet_key => merge(
-#{ name = "${var.naming.network_security_group}-${subnet_key}" },
-#lookup(subnet, "network_security_group", {})
-#)
-#if lookup(subnet, "network_security_group", null) != null
-#}
-#)
-#)
-
-#name = try(
-#each.value.name,
-#"${var.naming.network_security_group}-${each.key}"
-#)
-
-
-# network security groups
 resource "azurerm_network_security_group" "nsg" {
   for_each = merge(
     # Handle top-level shared NSGs
@@ -138,40 +107,6 @@ resource "azurerm_network_security_group" "nsg" {
     ignore_changes = [security_rule]
   }
 }
-
-#resource "azurerm_network_security_group" "nsg" {
-#for_each = merge(
-#lookup(var.vnet, "existing", null) != null ? lookup(lookup(var.vnet, "existing", {}), "network_security_groups", {}) : lookup(var.vnet, "network_security_groups", {}),
-#lookup(var.vnet, "existing", null) != null ? {
-#for subnet_key, subnet in lookup(lookup(var.vnet, "existing", {}), "subnets", {}) : subnet_key => subnet.network_security_group
-#if lookup(subnet, "network_security_group", null) != null
-#} : {
-#for subnet_key, subnet in lookup(var.vnet, "subnets", {}) : subnet_key => subnet.network_security_group
-#if lookup(subnet, "network_security_group", null) != null
-#}
-#)
-
-#name = try(
-#each.value.name,
-#"${var.naming.network_security_group}-${each.key}"
-#)
-
-#resource_group_name = lookup(var.vnet, "existing", null) != null ? var.vnet.existing.resource_group : coalesce(
-#var.vnet.resource_group,
-#var.resource_group
-#)
-
-#location = lookup(var.vnet, "existing", null) != null ? var.vnet.existing.location : coalesce(
-#var.vnet.location,
-#var.location
-#)
-
-#tags = try(var.vnet.tags, var.tags, {})
-
-#lifecycle {
-#ignore_changes = [security_rule]
-#}
-#}
 
 # security rules
 resource "azurerm_network_security_rule" "rules" {
@@ -234,19 +169,33 @@ resource "azurerm_network_security_rule" "rules" {
 # nsg associations
 resource "azurerm_subnet_network_security_group_association" "nsg_as" {
   for_each = {
-    for subnet_key, subnet in lookup(lookup(var.vnet, "existing", {}), "subnets", lookup(var.vnet, "subnets", {})) : subnet_key => subnet
-    if lookup(lookup(subnet, "shared", {}), "network_security_group", null) != null || lookup(subnet, "network_security_group", null) != null
+    for subnet_key, subnet in lookup(var.vnet, "subnets", {}) : subnet_key => subnet
+    if lookup(lookup(subnet, "shared", {}), "network_security_group", null) != null ||
+       lookup(subnet, "network_security_group", null) != null
   }
 
   subnet_id = azurerm_subnet.subnets[each.key].id
-  network_security_group_id = lookup(lookup(each.value, "shared", {}), "network_security_group", null) != null ? (
-    azurerm_network_security_group.nsg[lookup(each.value.shared, "network_security_group")].id
-  ) : azurerm_network_security_group.nsg[each.key].id
+  network_security_group_id = lookup(lookup(each.value, "shared", {}), "network_security_group", null) != null ? azurerm_network_security_group.nsg[lookup(each.value.shared, "network_security_group")].id : azurerm_network_security_group.nsg[each.key].id
 
   depends_on = [
     azurerm_network_security_rule.rules
   ]
 }
+#resource "azurerm_subnet_network_security_group_association" "nsg_as" {
+  #for_each = {
+    #for subnet_key, subnet in lookup(lookup(var.vnet, "existing", {}), "subnets", lookup(var.vnet, "subnets", {})) : subnet_key => subnet
+    #if lookup(lookup(subnet, "shared", {}), "network_security_group", null) != null || lookup(subnet, "network_security_group", null) != null
+  #}
+
+  #subnet_id = azurerm_subnet.subnets[each.key].id
+  #network_security_group_id = lookup(lookup(each.value, "shared", {}), "network_security_group", null) != null ? (
+    #azurerm_network_security_group.nsg[lookup(each.value.shared, "network_security_group")].id
+  #) : azurerm_network_security_group.nsg[each.key].id
+
+  #depends_on = [
+    #azurerm_network_security_rule.rules
+  #]
+#}
 
 # route tables
 resource "azurerm_route_table" "rt" {

--- a/main.tf
+++ b/main.tf
@@ -79,28 +79,15 @@ resource "azurerm_subnet" "subnets" {
   }
 }
 
-# network security groups
 resource "azurerm_network_security_group" "nsg" {
   for_each = merge(
-    # Handle top-level NSGs (shared ones)
-    lookup(var.vnet, "network_security_groups", {}),
-
-    # Handle subnet-level NSGs by first constructing the proper subnet map
-    {
-      for subnet_key, subnet in (
-        # First create a local to handle the subnets lookup
-        # to ensure consistent types between both paths
-        merge(
-          lookup(lookup(var.vnet, "existing", {}), "subnets", {}),
-          lookup(var.vnet, "existing", null) == null ? lookup(var.vnet, "subnets", {}) : {}
-        )
-      ) : subnet_key => (
-        lookup(lookup(subnet, "shared", {}), "network_security_group", null) != null ?
-          lookup(lookup(var.vnet, "network_security_groups", {}), lookup(subnet.shared, "network_security_group")) :
-          lookup(subnet, "network_security_group", {})
-      )
-      if lookup(lookup(subnet, "shared", {}), "network_security_group", null) != null ||
-         lookup(subnet, "network_security_group", null) != null
+    lookup(var.vnet, "existing", null) != null ? lookup(lookup(var.vnet, "existing", {}), "network_security_groups", {}) : lookup(var.vnet, "network_security_groups", {}),
+    lookup(var.vnet, "existing", null) != null ? {
+      for subnet_key, subnet in lookup(lookup(var.vnet, "existing", {}), "subnets", {}) : subnet_key => subnet.network_security_group
+      if lookup(subnet, "network_security_group", null) != null
+      } : {
+      for subnet_key, subnet in lookup(var.vnet, "subnets", {}) : subnet_key => subnet.network_security_group
+      if lookup(subnet, "network_security_group", null) != null
     }
   )
 
@@ -109,9 +96,15 @@ resource "azurerm_network_security_group" "nsg" {
     "${var.naming.network_security_group}-${each.key}"
   )
 
-  resource_group_name = lookup(var.vnet, "existing", null) != null ? var.vnet.existing.resource_group : coalesce(var.vnet.resource_group, var.resource_group)
+  resource_group_name = lookup(var.vnet, "existing", null) != null ? var.vnet.existing.resource_group : coalesce(
+    var.vnet.resource_group,
+    var.resource_group
+  )
 
-  location = lookup(var.vnet, "existing", null) != null ? var.vnet.existing.location : coalesce(var.vnet.location, var.location)
+  location = lookup(var.vnet, "existing", null) != null ? var.vnet.existing.location : coalesce(
+    var.vnet.location,
+    var.location
+  )
 
   tags = try(var.vnet.tags, var.tags, {})
 
@@ -119,44 +112,6 @@ resource "azurerm_network_security_group" "nsg" {
     ignore_changes = [security_rule]
   }
 }
-
- #network security groups
-#resource "azurerm_network_security_group" "nsg" {
-  #for_each = merge(
-     #Handle top-level NSGs (shared ones)
-    #lookup(var.vnet, "network_security_groups", {}),
-
-     #Handle subnet-level NSGs
-    #{
-      #for subnet_key, subnet in (
-        #lookup(var.vnet, "existing", null) != null ?
-          #lookup(lookup(var.vnet, "existing", {}), "subnets", {}) :
-          #lookup(var.vnet, "subnets", {})
-      #) : subnet_key => (
-        #lookup(lookup(subnet, "shared", {}), "network_security_group", null) != null ?
-          #lookup(lookup(var.vnet, "network_security_groups", {}), lookup(subnet.shared, "network_security_group")) :
-          #lookup(subnet, "network_security_group", {})
-      #)
-      #if lookup(lookup(subnet, "shared", {}), "network_security_group", null) != null ||
-         #lookup(subnet, "network_security_group", null) != null
-    #}
-  #)
-
-  #name = try(
-    #each.value.name,
-    #"${var.naming.network_security_group}-${each.key}"
-  #)
-
-  #resource_group_name = lookup(var.vnet, "existing", null) != null ? var.vnet.existing.resource_group : coalesce(var.vnet.resource_group, var.resource_group)
-
-  #location = lookup(var.vnet, "existing", null) != null ? var.vnet.existing.location : coalesce(var.vnet.location, var.location)
-
-  #tags = try(var.vnet.tags, var.tags, {})
-
-  #lifecycle {
-    #ignore_changes = [security_rule]
-  #}
-#}
 
 # security rules
 resource "azurerm_network_security_rule" "rules" {
@@ -219,41 +174,19 @@ resource "azurerm_network_security_rule" "rules" {
 # nsg associations
 resource "azurerm_subnet_network_security_group_association" "nsg_as" {
   for_each = {
-    for subnet_key, subnet in merge(
-      lookup(lookup(var.vnet, "existing", {}), "subnets", {}),
-      lookup(var.vnet, "existing", null) == null ? lookup(var.vnet, "subnets", {}) : {}
-    ) : subnet_key => subnet
-    if lookup(lookup(subnet, "shared", {}), "network_security_group", null) != null ||
-       lookup(subnet, "network_security_group", null) != null
+    for subnet_key, subnet in lookup(lookup(var.vnet, "existing", {}), "subnets", lookup(var.vnet, "subnets", {})) : subnet_key => subnet
+    if lookup(lookup(subnet, "shared", {}), "network_security_group", null) != null || lookup(subnet, "network_security_group", null) != null
   }
 
   subnet_id = azurerm_subnet.subnets[each.key].id
-  network_security_group_id = lookup(lookup(each.value, "shared", {}), "network_security_group", null) != null ? azurerm_network_security_group.nsg[lookup(each.value.shared, "network_security_group")].id : azurerm_network_security_group.nsg[each.key].id
+  network_security_group_id = lookup(lookup(each.value, "shared", {}), "network_security_group", null) != null ? (
+    azurerm_network_security_group.nsg[lookup(each.value.shared, "network_security_group")].id
+  ) : azurerm_network_security_group.nsg[each.key].id
 
   depends_on = [
     azurerm_network_security_rule.rules
   ]
 }
-
- #nsg associations
-#resource "azurerm_subnet_network_security_group_association" "nsg_as" {
-  #for_each = {
-    #for subnet_key, subnet in (
-      #lookup(var.vnet, "existing", null) != null ?
-        #lookup(lookup(var.vnet, "existing", {}), "subnets", {}) :
-        #lookup(var.vnet, "subnets", {})
-    #) : subnet_key => subnet
-    #if lookup(lookup(subnet, "shared", {}), "network_security_group", null) != null ||
-       #lookup(subnet, "network_security_group", null) != null
-  #}
-
-  #subnet_id = azurerm_subnet.subnets[each.key].id
-  #network_security_group_id = lookup(lookup(each.value, "shared", {}), "network_security_group", null) != null ? azurerm_network_security_group.nsg[lookup(each.value.shared, "network_security_group")].id : azurerm_network_security_group.nsg[each.key].id
-
-  #depends_on = [
-    #azurerm_network_security_rule.rules
-  #]
-#}
 
 # route tables
 resource "azurerm_route_table" "rt" {

--- a/main.tf
+++ b/main.tf
@@ -87,8 +87,6 @@ resource "azurerm_network_security_group" "nsg" {
 
     # Handle subnet NSGs
     {
-      #for subnet_key, subnet in lookup(var.vnet, "subnets", {}) : subnet_key => lookup(subnet, "network_security_group", {})
-      #if lookup(subnet, "network_security_group", null) != null
       for subnet_key, subnet in lookup(lookup(var.vnet, "existing", {}), "subnets", lookup(var.vnet, "subnets", {})) : subnet_key => lookup(subnet, "network_security_group", null)
       if lookup(subnet, "network_security_group", null) != null
     }
@@ -168,24 +166,7 @@ resource "azurerm_network_security_rule" "rules" {
   )
 }
 
-# FIX: nsg + associoation is not working on existing virtual network
 # nsg associations
-#resource "azurerm_subnet_network_security_group_association" "nsg_as" {
-#for_each = {
-#for subnet_key, subnet in lookup(var.vnet, "subnets", {}) : subnet_key => subnet
-#if lookup(lookup(subnet, "shared", {}), "network_security_group", null) != null ||
-#lookup(subnet, "network_security_group", null) != null
-#}
-
-#subnet_id                 = azurerm_subnet.subnets[each.key].id
-#network_security_group_id = lookup(lookup(each.value, "shared", {}), "network_security_group", null) != null ? azurerm_network_security_group.nsg[lookup(each.value.shared, "network_security_group")].id : azurerm_network_security_group.nsg[each.key].id
-
-#depends_on = [
-#azurerm_network_security_rule.rules
-#]
-#}
-
-
 resource "azurerm_subnet_network_security_group_association" "nsg_as" {
   for_each = {
     for subnet_key, subnet in lookup(lookup(var.vnet, "existing", {}), "subnets", lookup(var.vnet, "subnets", {})) : subnet_key => subnet


### PR DESCRIPTION
## Description

This PR fixes the below error in some specific scenario.

```
Error: Inconsistent conditional result types
  on ../../main.tf line 90, in resource "azurerm_network_security_group" "nsg":
  89:       for subnet_key, subnet in lookup(var.vnet, "existing", null) != null ?
  90:         lookup(lookup(var.vnet, "existing", {}), "subnets", {}) :
  91:         lookup(var.vnet, "subnets", {}) : subnet_key => merge(
    ├────────────────
    │ var.vnet is object with 6 attributes
The true and false result expressions must have consistent types. The 'false'
value includes object attribute "bastion", which is absent in the 'true'
value.}
```

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)