### PR TITLE
feat: added private endpoint vnet policies support and remove temporary files when deployment tests fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,13 @@ End-to-end testing is not conducted on these modules, as they are individual com
 
 ## Features
 
-- dedicated network security group for each subnet, capable of managing multiple rules
+- optional network security group for each subnet, capable of managing multiple rules
+- association of a single network security group with multiple subnets
 - support for multiple service endpoints and delegations, including actions
 - utilization of terratest for robust validation
 - route table support with multiple user defined routes
 - association of multiple subnets with a single route table
-- optional virtual hub connections for enhanced network integration
+- optional virtual network peering for enhanced network integration
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/main.tf
+++ b/main.tf
@@ -15,9 +15,10 @@ resource "azurerm_virtual_network" "vnet" {
   name                = var.vnet.name
   address_space       = var.vnet.address_space
 
-  edge_zone               = try(var.vnet.edge_zone, null)
-  bgp_community           = try(var.vnet.bgp_community, null)
-  flow_timeout_in_minutes = try(var.vnet.flow_timeout_in_minutes, null)
+  edge_zone                      = try(var.vnet.edge_zone, null)
+  bgp_community                  = try(var.vnet.bgp_community, null)
+  flow_timeout_in_minutes        = try(var.vnet.flow_timeout_in_minutes, null)
+  private_endpoint_vnet_policies = try(var.vnet.private_endpoint_vnet_policies, null)
 
   dynamic "ddos_protection_plan" {
     for_each = lookup(var.vnet, "ddos_protection_plan", null) != null ? [lookup(var.vnet, "ddos_protection_plan", null)] : []

--- a/tests/deploy_test.go
+++ b/tests/deploy_test.go
@@ -95,13 +95,18 @@ func (m *Module) Apply(t *testing.T) error {
 func (m *Module) Destroy(t *testing.T) error {
 	t.Helper()
 	t.Logf("Destroying Terraform module: %s", m.Name)
-	_, err := terraform.DestroyE(t, m.Options)
-	if err != nil {
-		return fmt.Errorf("destroy failed: %v", err)
+	_, destroyErr := terraform.DestroyE(t, m.Options) // Discard stdout, capture only error
+
+	cleanupErr := m.cleanupFiles(t)
+
+	if cleanupErr != nil {
+		return fmt.Errorf("cleanup failed: %v (original destroy error: %v)", cleanupErr, destroyErr)
 	}
-	if err := m.cleanupFiles(t); err != nil {
-		return fmt.Errorf("cleanup failed: %v", err)
+
+	if destroyErr != nil {
+		return fmt.Errorf("destroy failed: %v", destroyErr)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Description

`private_endpoint_vnet_policies` is added on the virtual network and the deployment tests now properly removes temporary files when deployment tests are failing. The documentation is also slightly updated.

```
--- PASS: TestApplyAllParallel (0.00s)
    --- PASS: TestApplyAllParallel/default (109.02s)
    --- PASS: TestApplyAllParallel/service-endpoints (138.54s)
    --- PASS: TestApplyAllParallel/delegations (145.43s)
    --- PASS: TestApplyAllParallel/peering (162.05s)
    --- PASS: TestApplyAllParallel/nsg-rules (186.20s)
    --- PASS: TestApplyAllParallel/routes (202.51s)
    --- PASS: TestApplyAllParallel/complete (212.29s)
PASS
ok      github.com/cloudnationhq/terraform-azure-vnet   212.676s
```

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)