### PR TITLE
fix: vnet peering name override

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ For more information, please see our contribution [guidelines](https://github.co
 
 MIT Licensed. See [LICENSE](https://github.com/cloudnationhq/terraform-azure-vnet/blob/main/LICENSE) for full details.
 
-## Reference
+## References
 
 - [Documentation](https://learn.microsoft.com/en-us/azure/virtual-network/)
 - [Rest Api](https://learn.microsoft.com/en-us/rest/api/virtual-network/)

--- a/examples/peering/main.tf
+++ b/examples/peering/main.tf
@@ -76,12 +76,14 @@ module "peering" {
 
   vnet_peering = {
     local = {
+      peering_name        = "local-to-remote"
       name                = module.vnet_local.vnet.name
       id                  = module.vnet_local.vnet.id
       resource_group_name = module.vnet_local.vnet.resource_group_name
       address_space       = module.vnet_local.vnet.address_space
     }
     remote = {
+      peering_name        = "remote-to-local"
       name                = module.vnet_remote.vnet.name
       id                  = module.vnet_remote.vnet.id
       resource_group_name = module.vnet_remote.vnet.resource_group_name

--- a/modules/vnet-peering/main.tf
+++ b/modules/vnet-peering/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_virtual_network_peering" "local_to_remote" {
-  name                                   = "peer-${substr(var.vnet_peering.local.name, 0, 35)}-to-${substr(var.vnet_peering.remote.name, 0, 35)}"
+  name                                   = try(var.vnet_peering.local.peering_name, "peer-${substr(var.vnet_peering.local.name, 0, 35)}-to-${substr(var.vnet_peering.remote.name, 0, 35)}")
   resource_group_name                    = var.vnet_peering.local.resource_group_name
   virtual_network_name                   = var.vnet_peering.local.name
   remote_virtual_network_id              = var.vnet_peering.remote.id
@@ -17,7 +17,7 @@ resource "azurerm_virtual_network_peering" "local_to_remote" {
 }
 
 resource "azurerm_virtual_network_peering" "remote_to_local" {
-  name                                   = "peer-${substr(var.vnet_peering.remote.name, 0, 35)}-to-${substr(var.vnet_peering.local.name, 0, 35)}"
+  name                                   = try(var.vnet_peering.remote.peering_name, "peer-${substr(var.vnet_peering.remote.name, 0, 35)}-to-${substr(var.vnet_peering.local.name, 0, 35)}")
   resource_group_name                    = var.vnet_peering.remote.resource_group_name
   virtual_network_name                   = var.vnet_peering.remote.name
   remote_virtual_network_id              = var.vnet_peering.local.id


### PR DESCRIPTION
## Description

Override name property now possible for peering name. 


## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [ ] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have made corresponding changes to the documentation
- [ ] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Change Log

Below please provide what should go into the changelog (if anything) 

<!-- Replace the changelog example below with your entry. One resource per line. -->

 * `azurerm_resource` - support for the `example` property


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #131 
