### PR TITLE
fix: improve handling of null values in network security rule attributes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -221,24 +221,31 @@ resource "azurerm_network_security_rule" "rules" {
     ]) : pair.key => pair.value
   })
 
-  name                                       = each.value.rule_name
-  priority                                   = each.value.rule.priority
-  direction                                  = each.value.rule.direction
-  access                                     = each.value.rule.access
-  protocol                                   = each.value.rule.protocol
-  source_port_range                          = each.value.rule.source_port_range
-  source_port_ranges                         = length(coalesce(each.value.rule.source_port_ranges, [])) > 0 ? each.value.rule.source_port_ranges : null
-  destination_port_range                     = each.value.rule.destination_port_range
-  destination_port_ranges                    = length(coalesce(each.value.rule.destination_port_ranges, [])) > 0 ? each.value.rule.destination_port_ranges : null
-  source_address_prefix                      = each.value.rule.source_address_prefix
-  source_address_prefixes                    = length(coalesce(each.value.rule.source_address_prefixes, [])) > 0 ? each.value.rule.source_address_prefixes : null
-  destination_address_prefix                 = each.value.rule.destination_address_prefix
-  destination_address_prefixes               = length(coalesce(each.value.rule.destination_address_prefixes, [])) > 0 ? each.value.rule.destination_address_prefixes : null
-  description                                = each.value.rule.description
-  network_security_group_name                = each.value.nsg_name
-  source_application_security_group_ids      = each.value.rule.source_application_security_group_ids
-  destination_application_security_group_ids = each.value.rule.destination_application_security_group_ids
-
+  name      = each.value.rule_name
+  priority  = each.value.rule.priority
+  direction = each.value.rule.direction
+  access    = each.value.rule.access
+  protocol  = each.value.rule.protocol
+  source_address_prefix = (
+    each.value.rule.source_address_prefix != null ? each.value.rule.source_address_prefix : null
+  )
+  source_address_prefixes = (
+    each.value.rule.source_address_prefix == null && length(coalesce(each.value.rule.source_address_prefixes, [])) > 0 ? each.value.rule.source_address_prefixes : null
+  )
+  source_application_security_group_ids = (
+    each.value.rule.source_address_prefix == null && length(coalesce(each.value.rule.source_address_prefixes, [])) == 0 && length(coalesce(each.value.rule.source_application_security_group_ids, [])) > 0 ? each.value.rule.source_application_security_group_ids : null
+  )
+  destination_address_prefix = (
+    each.value.rule.destination_address_prefix != null ? each.value.rule.destination_address_prefix : null
+  )
+  destination_address_prefixes = (
+    each.value.rule.destination_address_prefix == null && length(coalesce(each.value.rule.destination_address_prefixes, [])) > 0 ? each.value.rule.destination_address_prefixes : null
+  )
+  destination_application_security_group_ids = (
+    each.value.rule.destination_address_prefix == null && length(coalesce(each.value.rule.destination_address_prefixes, [])) == 0 && length(coalesce(each.value.rule.destination_application_security_group_ids, [])) > 0 ? each.value.rule.destination_application_security_group_ids : null
+  )
+  description                 = each.value.rule.description
+  network_security_group_name = each.value.nsg_name
   resource_group_name = coalesce(
     lookup(
       var.vnet, "resource_group_name", null


### PR DESCRIPTION
## Description

due to added validations in azurerm version 4.38 the vnet module was broken and security rules could not be created. The fix ensures that for each NSG rule, only one of the mutually exclusive fields (source_address_prefix, source_address_prefixes, or source_application_security_group_ids—and the same for destination) is set at a time.


## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have made corresponding changes to the documentation
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.


## Change Log

Below please provide what should go into the changelog (if anything) 

 * `azurerm_network_security_rule` - fix for additional validation steps in azurerm version 4.38.0


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #173
